### PR TITLE
feat(docker): adds part to README + updates prod environment URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,37 @@ If you are a developer and are interested in this open source solution, then you
 
 ### running in docker
 
-xxx
+To run the application with docker you first need the `.env` file as described in the [getting started](#getting-started).
+
+The easiest way to start the whole application is by using `docker-compose`.
+To use it you have to define a `docker-compose.yml` with a content like the following:
+
+```yaml
+version: '3'
+services:
+  undressor-frontend:
+    image: ghcr.io/thecodemonkey/undressor-frontend:latest
+    ports:
+      - 8080:8080
+  undressor-api:
+    image: ghcr.io/thecodemonkey/undressor-api:latest
+    env_file: .env
+    ports:
+      - ${PORT}:${PORT}
+  undressor-bot:
+    image: ghcr.io/thecodemonkey/undressor-bot:latest
+    env_file: .env
+    ports:
+      - 27016:27017
+```
+
+The containers can be started by running `docker-compose up`.
+If you want to update the images, because we updated them, you can run those commands:
+
+```sh
+docker-compose up --force-recreate --build -d
+docker image prune -f
+```
 
 <br/><br/>
 

--- a/ui/src/environments/environment.prod.ts
+++ b/ui/src/environments/environment.prod.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: true,
-  apiUrl: 'https://undressor.herokuapp.com/'
+  apiUrl: 'https://3f04f8f.online-server.cloud/undressor/'
 };


### PR DESCRIPTION
This should close #2.
If there is anything you're missing inside the README, just tell me!
Also, I read the rest of the README, pretty good work!

Last but not least, I updated the URL of the production-server that we no longer depend on Heroku not getting sleepy 😃 
I can also update the workflow, that the server is build automatically, but I need to have access to add secrets to this repository as I need to authenticate to the CentOS server the API is running on.
But it would also not be a problem to do that manually, as it's not much work to pull new images and rebuild the containers 😉 